### PR TITLE
Update KVS AAC audio type

### DIFF
--- a/samples/kvs/source/sample_config.h
+++ b/samples/kvs/source/sample_config.h
@@ -49,7 +49,7 @@
 
 #if USE_AUDIO_AAC
 #define AUDIO_CODEC_NAME                "A_AAC"
-#define AUDIO_MPEG_OBJECT_TYPE          AAC_LC
+#define AUDIO_MPEG_OBJECT_TYPE          MPEG4_AAC_LC
 #endif /* USE_AUDIO_AAC */
 
 #if USE_AUDIO_G711


### PR DESCRIPTION
KVS has recently changed on MPEG4 audio enum type because the original one conflicts with WebRTC. It also needs to sync and update the audio type here.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
