### PR TITLE
kvs: update kvs to ad6860365c75ab19b8aa4148c305cc6cbb37eeeb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 3rdparty/T31/
+3rdparty/V4L2/
 build/

--- a/3rdparty/README.md
+++ b/3rdparty/README.md
@@ -2,6 +2,16 @@
 
 Put board sdk here.
 
+# V4L2
+
+V4L2 request libv4l2 on your build device. You may install it via:
+
+```
+sudo apt install libv4l-dev
+```
+
+Other dependencies will be downloaded and build by cmake.
+
 # T31
 
 ```

--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@
 
 ## Introduction
 
-**Amazon Kinesis Video Streams Media Interface** provides abstract interfaces for board specific media APIs. This repository also contains SoCs sensors/encoder implementations for Amazon Kinesis Video Streams Producer and WebRTC with out-of-box samples.
+**Amazon Kinesis Video Streams Media Interface** provides abstract interfaces for board specific media APIs. This repository also contains boards sensors/encoder implementations for Amazon Kinesis Video Streams Producer and WebRTC with out-of-box samples.
 
-## Supported SoCs
+## Supported Boards
 
-- T31
+- x86/x84(By selecting board `V4L2`)
+- RPi(By selecting board `V4L2`)
+- T31(By selecting board `T31`)
 
 ## Getting started with out-of-box KVS WebRTC sample
 

--- a/samples/kvs/CMakeLists.txt
+++ b/samples/kvs/CMakeLists.txt
@@ -14,8 +14,8 @@ message(STATUS "EMBEDDED_MEDIA_LINK_DIR - ${EMBEDDED_MEDIA_LINK_DIR}")
 include(ExternalProject)
 ExternalProject_Add(kvs-producer
   GIT_REPOSITORY    https://github.com/aws-samples/amazon-kinesis-video-streams-producer-embedded-c.git
-  GIT_TAG           1704816bed9f9bfa70f2dc531081adb275c72d33
-  CMAKE_ARGS        -DBUILD_SHARED_SAMPLES=ON -DBUILD_STATIC_SAMPLES=ON -DCMAKE_INSTALL_PREFIX=${AWS_DEPENDENCIES_DIR}/kvs/ -DCMAKE_BUILD_TYPE=Release
+  GIT_TAG           ad6860365c75ab19b8aa4148c305cc6cbb37eeeb
+  CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX=${AWS_DEPENDENCIES_DIR}/kvs/ -DCMAKE_BUILD_TYPE=Release
   BUILD_ALWAYS      TRUE
   GIT_PROGRESS      TRUE
   TEST_COMMAND      ""
@@ -26,7 +26,6 @@ set(KVS_SAMPLE_SRCS
     ${CMAKE_CURRENT_LIST_DIR}/source/option_configuration.c)
 
 set(KVS_SDK_LIBS_SHARED
-    kvsapp
     kvs-embedded-c
     mbedtls
     mbedcrypto
@@ -39,7 +38,6 @@ set(KVS_SDK_LIBS_SHARED
     m)
 
 set(KVS_SDK_LIBS_STATIC
-    libkvsapp.a
     libkvs-embedded-c.a
     libmbedtls.a
     libmbedx509.a

--- a/samples/kvs/source/kvsappcli.c
+++ b/samples/kvs/source/kvsappcli.c
@@ -115,7 +115,7 @@ static int setKvsAppOptions(KvsAppHandle kvsAppHandle)
 
 #if ENABLE_AUDIO_TRACK
     if (KvsApp_setoption(kvsAppHandle, OPTION_KVS_AUDIO_TRACK_INFO, (const char*) (&audioTrackInfo)) != 0) {
-        printf("Failed to set video track info\n");
+        printf("Failed to set audio track info\n");
     }
 #endif /* ENABLE_AUDIO_TRACK */
 
@@ -233,8 +233,8 @@ int main(int argc, char* argv[])
     Mkv_generatePcmCodecPrivateData(AUDIO_PCM_OBJECT_TYPE, audioTrackInfo.uFrequency, audioTrackInfo.uChannelNumber, &audioTrackInfo.pCodecPrivate,
                                     &audioTrackInfo.uCodecPrivateLen);
 #elif USE_AUDIO_AAC
-    Mkv_generateAacCodecPrivateData(AUDIO_MPEG_OBJECT_TYPE, audioTrackInfo.uFrequency, audioTrackInfo.uChannelNumber, &pCodecPrivateData,
-                                    &uCodecPrivateDataLen);
+    Mkv_generateAacCodecPrivateData(AUDIO_MPEG_OBJECT_TYPE, audioTrackInfo.uFrequency, audioTrackInfo.uChannelNumber, &audioTrackInfo.pCodecPrivate,
+                                    &audioTrackInfo.uCodecPrivateLen);
 #endif
 #endif
 

--- a/samples/kvs/source/option_configuration.c
+++ b/samples/kvs/source/option_configuration.c
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/samples/kvs/source/option_configuration.h
+++ b/samples/kvs/source/option_configuration.h
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 #ifndef SAMPLE_OPTIONS_H
 #define SAMPLE_OPTIONS_H
 

--- a/samples/kvs/source/sample_config.h
+++ b/samples/kvs/source/sample_config.h
@@ -40,8 +40,8 @@
 
 /* Audio configuration */
 #if ENABLE_AUDIO_TRACK
-#define USE_AUDIO_AAC                   0   /* Set to 1 to use AAC as audio track */
-#define USE_AUDIO_G711                  1   /* Set to 1 to use G711 as audio track */
+#define USE_AUDIO_AAC                   1   /* Set to 1 to use AAC as audio track */
+#define USE_AUDIO_G711                  0   /* Set to 1 to use G711 as audio track */
 
 #if (USE_AUDIO_AAC == 0) && (USE_AUDIO_G711 == 0)
 #error "Please select audio source"
@@ -104,7 +104,7 @@
 /**
  * Get the size of stream buffer.  If there is no buffer limit, then assume it's 2M bytes.
  */
-#ifdef ENABLE_RING_BUFFER_MEM_LIMIT
+#if ENABLE_RING_BUFFER_MEM_LIMIT
 #define BUFFER_MEM_LIMIT        RING_BUFFER_MEM_LIMIT
 #else
 #define BUFFER_MEM_LIMIT        (2 * 1024 * 1024)


### PR DESCRIPTION
Signed-off-by: zhiqinli@amazon.com <zhiqinli@amazon.com>

*Issue #, if available:*
#22 
*Description of changes:*
This PR will dump KVS producer SDK to ad6860365c75ab19b8aa4148c305cc6cbb37eeeb and fix build error when specifying AAC encoder.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
