### PR TITLE
improve support for c++ toolchains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 3rdparty/T31/
 3rdparty/V4L2/
 3rdparty/FH8626V100/
+3rdparty/C302/
 build/

--- a/include/com/amazonaws/kinesis/video/capturer/AudioCapturer.h
+++ b/include/com/amazonaws/kinesis/video/capturer/AudioCapturer.h
@@ -46,7 +46,7 @@ AudioCapturerHandle audioCapturerCreate(void);
  * @param[in] handle Handle of AudioCapturer.
  * @return AudioCapturerStatus
  */
-AudioCapturerStatus audioCapturerGetStatus(const AudioCapturerHandle const handle);
+AudioCapturerStatus audioCapturerGetStatus(const AudioCapturerHandle handle);
 
 /**
  * @brief Get capturer capability.
@@ -55,7 +55,7 @@ AudioCapturerStatus audioCapturerGetStatus(const AudioCapturerHandle const handl
  * @param[out] pCapability Capturer capability.
  * @return int 0 or error code.
  */
-int audioCapturerGetCapability(const AudioCapturerHandle const handle, AudioCapability* pCapability);
+int audioCapturerGetCapability(const AudioCapturerHandle handle, AudioCapability* pCapability);
 
 /**
  * @brief Set capturer format, channel number, bit depth and sample rate.
@@ -80,7 +80,7 @@ int audioCapturerSetFormat(AudioCapturerHandle handle, const AudioFormat format,
  * @param[in] pBitDepth Frame bit depth.
  * @return int 0 or error code.
  */
-int audioCapturerGetFormat(const AudioCapturerHandle const handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
+int audioCapturerGetFormat(const AudioCapturerHandle handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
                            AudioBitDepth* pBitDepth);
 
 /**

--- a/include/com/amazonaws/kinesis/video/capturer/VideoCapturer.h
+++ b/include/com/amazonaws/kinesis/video/capturer/VideoCapturer.h
@@ -46,7 +46,7 @@ VideoCapturerHandle videoCapturerCreate(void);
  * @param[in] handle Handle of VideoCapturer.
  * @return VideoCapturerStatus Status of VideoCapturer.
  */
-VideoCapturerStatus videoCapturerGetStatus(const VideoCapturerHandle const handle);
+VideoCapturerStatus videoCapturerGetStatus(const VideoCapturerHandle handle);
 
 /**
  * @brief Get capturer capability.
@@ -55,7 +55,7 @@ VideoCapturerStatus videoCapturerGetStatus(const VideoCapturerHandle const handl
  * @param[out] pCapability Capturer capability.
  * @return int 0 or error code.
  */
-int videoCapturerGetCapability(const VideoCapturerHandle const handle, VideoCapability* pCapability);
+int videoCapturerGetCapability(const VideoCapturerHandle handle, VideoCapability* pCapability);
 
 /**
  * @brief Set capturer format and resolution.
@@ -75,7 +75,7 @@ int videoCapturerSetFormat(VideoCapturerHandle handle, const VideoFormat format,
  * @param[out] pResolution Frame resolution.
  * @return int 0 or error code.
  */
-int videoCapturerGetFormat(const VideoCapturerHandle const handle, VideoFormat* pFormat, VideoResolution* pResolution);
+int videoCapturerGetFormat(const VideoCapturerHandle handle, VideoFormat* pFormat, VideoResolution* pResolution);
 
 /**
  * @brief Acquire and turn on video stream.

--- a/include/com/amazonaws/kinesis/video/player/AudioPlayer.h
+++ b/include/com/amazonaws/kinesis/video/player/AudioPlayer.h
@@ -46,7 +46,7 @@ AudioPlayerHandle audioPlayerCreate(void);
  * @param[in] handle Handle of AudioPlayer.
  * @return AudioPlayerStatus Status of AudioPlayer.
  */
-AudioPlayerStatus audioPlayerGetStatus(const AudioPlayerHandle const handle);
+AudioPlayerStatus audioPlayerGetStatus(const AudioPlayerHandle handle);
 
 /**
  * @brief Get player capability.
@@ -55,7 +55,7 @@ AudioPlayerStatus audioPlayerGetStatus(const AudioPlayerHandle const handle);
  * @param[out] pCapability Player capability.
  * @return int 0 or error code.
  */
-int audioPlayerGetCapability(const AudioPlayerHandle const handle, AudioCapability* pCapability);
+int audioPlayerGetCapability(const AudioPlayerHandle handle, AudioCapability* pCapability);
 
 /**
  * @brief Set player format, channel number, bit depth and sample rate.
@@ -80,7 +80,7 @@ int audioPlayerSetFormat(AudioPlayerHandle handle, const AudioFormat format, con
  * @param[in] pBitDepth Frame bit depth.
  * @return int 0 or error code.
  */
-int audioPlayerGetFormat(const AudioPlayerHandle const handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
+int audioPlayerGetFormat(const AudioPlayerHandle handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
                          AudioBitDepth* pBitDepth);
 
 /**

--- a/source/AK3918/AK3918AudioCapturer.c
+++ b/source/AK3918/AK3918AudioCapturer.c
@@ -83,7 +83,7 @@ AudioCapturerHandle audioCapturerCreate(void)
     return (AudioCapturerHandle) AK3918Handle;
 }
 
-AudioCapturerStatus audioCapturerGetStatus(const AudioCapturerHandle const handle)
+AudioCapturerStatus audioCapturerGetStatus(const AudioCapturerHandle handle)
 {
     if (!handle) {
         return AUD_CAP_STATUS_NOT_READY;
@@ -94,7 +94,7 @@ AudioCapturerStatus audioCapturerGetStatus(const AudioCapturerHandle const handl
     return AK3918Handle->status;
 }
 
-int audioCapturerGetCapability(const AudioCapturerHandle const handle, AudioCapability* pCapability)
+int audioCapturerGetCapability(const AudioCapturerHandle handle, AudioCapability* pCapability)
 {
     AK3918_HANDLE_NULL_CHECK(handle);
     AK3918_HANDLE_GET(handle);
@@ -161,7 +161,7 @@ int audioCapturerSetFormat(AudioCapturerHandle handle, const AudioFormat format,
     return 0;
 }
 
-int audioCapturerGetFormat(const AudioCapturerHandle const handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
+int audioCapturerGetFormat(const AudioCapturerHandle handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
                            AudioBitDepth* pBitDepth)
 {
     AK3918_HANDLE_NULL_CHECK(handle);

--- a/source/AK3918/AK3918AudioPlayer.c
+++ b/source/AK3918/AK3918AudioPlayer.c
@@ -67,7 +67,7 @@ AudioPlayerHandle audioPlayerCreate(void)
     return (AudioPlayerHandle) AK3918Handle;
 }
 
-AudioPlayerStatus audioPlayerGetStatus(const AudioPlayerHandle const handle)
+AudioPlayerStatus audioPlayerGetStatus(const AudioPlayerHandle handle)
 {
     if (!handle) {
         return AUD_PLY_STATUS_NOT_READY;
@@ -78,7 +78,7 @@ AudioPlayerStatus audioPlayerGetStatus(const AudioPlayerHandle const handle)
     return AK3918Handle->status;
 }
 
-int audioPlayerGetCapability(const AudioPlayerHandle const handle, AudioCapability* pCapability)
+int audioPlayerGetCapability(const AudioPlayerHandle handle, AudioCapability* pCapability)
 {
     AK3918_HANDLE_NULL_CHECK(handle);
     AK3918_HANDLE_GET(handle);
@@ -155,7 +155,7 @@ int audioPlayerSetFormat(AudioPlayerHandle handle, const AudioFormat format, con
     return 0;
 }
 
-int audioPlayerGetFormat(const AudioPlayerHandle const handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
+int audioPlayerGetFormat(const AudioPlayerHandle handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
                          AudioBitDepth* pBitDepth)
 {
     AK3918_HANDLE_NULL_CHECK(handle);

--- a/source/AK3918/AK3918VideoCapturer.c
+++ b/source/AK3918/AK3918VideoCapturer.c
@@ -69,7 +69,7 @@ VideoCapturerHandle videoCapturerCreate(void)
     return (VideoCapturerHandle) AK3918Handle;
 }
 
-VideoCapturerStatus videoCapturerGetStatus(const VideoCapturerHandle const handle)
+VideoCapturerStatus videoCapturerGetStatus(const VideoCapturerHandle handle)
 {
     if (!handle) {
         return VID_CAP_STATUS_NOT_READY;
@@ -80,7 +80,7 @@ VideoCapturerStatus videoCapturerGetStatus(const VideoCapturerHandle const handl
     return AK3918Handle->status;
 }
 
-int videoCapturerGetCapability(const VideoCapturerHandle const handle, VideoCapability* pCapability)
+int videoCapturerGetCapability(const VideoCapturerHandle handle, VideoCapability* pCapability)
 {
     AK3918_HANDLE_NULL_CHECK(handle);
     AK3918_HANDLE_GET(handle);
@@ -125,7 +125,7 @@ int videoCapturerSetFormat(VideoCapturerHandle handle, const VideoFormat format,
     return 0;
 }
 
-int videoCapturerGetFormat(const VideoCapturerHandle const handle, VideoFormat* pFormat, VideoResolution* pResolution)
+int videoCapturerGetFormat(const VideoCapturerHandle handle, VideoFormat* pFormat, VideoResolution* pResolution)
 {
     AK3918_HANDLE_NULL_CHECK(handle);
     AK3918_HANDLE_GET(handle);

--- a/source/C302/C302AudioCapturer.c
+++ b/source/C302/C302AudioCapturer.c
@@ -76,7 +76,7 @@ AudioCapturerHandle audioCapturerCreate(void)
     return (AudioCapturerHandle) audioHandle;
 }
 
-AudioCapturerStatus audioCapturerGetStatus(const AudioCapturerHandle const handle)
+AudioCapturerStatus audioCapturerGetStatus(const AudioCapturerHandle handle)
 {
     if (!handle) {
         return AUD_CAP_STATUS_NOT_READY;
@@ -86,7 +86,7 @@ AudioCapturerStatus audioCapturerGetStatus(const AudioCapturerHandle const handl
     return audioHandle->status;
 }
 
-int audioCapturerGetCapability(const AudioCapturerHandle const handle, AudioCapability* pCapability)
+int audioCapturerGetCapability(const AudioCapturerHandle handle, AudioCapability* pCapability)
 {
     HANDLE_NULL_CHECK(handle);
     C302_HANDLE_GET(handle);
@@ -190,7 +190,7 @@ int audioCapturerSetFormat(AudioCapturerHandle handle, const AudioFormat format,
     return 0;
 }
 
-int audioCapturerGetFormat(const AudioCapturerHandle const handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
+int audioCapturerGetFormat(const AudioCapturerHandle handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
                            AudioBitDepth* pBitDepth)
 {
     HANDLE_NULL_CHECK(handle);

--- a/source/C302/C302AudioPlayer.c
+++ b/source/C302/C302AudioPlayer.c
@@ -76,7 +76,7 @@ AudioPlayerHandle audioPlayerCreate(void)
     return (AudioPlayerHandle) audioHandle;
 }
 
-AudioPlayerStatus audioPlayerGetStatus(const AudioPlayerHandle const handle)
+AudioPlayerStatus audioPlayerGetStatus(const AudioPlayerHandle handle)
 {
     if (!handle) {
         return AUD_PLY_STATUS_NOT_READY;
@@ -86,7 +86,7 @@ AudioPlayerStatus audioPlayerGetStatus(const AudioPlayerHandle const handle)
     return audioHandle->status;
 }
 
-int audioPlayerGetCapability(const AudioPlayerHandle const handle, AudioCapability* pCapability)
+int audioPlayerGetCapability(const AudioPlayerHandle handle, AudioCapability* pCapability)
 {
     HANDLE_NULL_CHECK(handle);
     C302_HANDLE_GET(handle);
@@ -186,7 +186,7 @@ int audioPlayerSetFormat(AudioPlayerHandle handle, const AudioFormat format, con
     return 0;
 }
 
-int audioPlayerGetFormat(const AudioPlayerHandle const handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
+int audioPlayerGetFormat(const AudioPlayerHandle handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
                          AudioBitDepth* pBitDepth)
 {
     HANDLE_NULL_CHECK(handle);

--- a/source/C302/C302VideoCapturer.c
+++ b/source/C302/C302VideoCapturer.c
@@ -116,7 +116,7 @@ VideoCapturerHandle videoCapturerCreate(void)
     return (VideoCapturerHandle) videoHandle;
 }
 
-VideoCapturerStatus videoCapturerGetStatus(const VideoCapturerHandle const handle)
+VideoCapturerStatus videoCapturerGetStatus(const VideoCapturerHandle handle)
 {
     if (!handle) {
         return VID_CAP_STATUS_NOT_READY;
@@ -127,7 +127,7 @@ VideoCapturerStatus videoCapturerGetStatus(const VideoCapturerHandle const handl
     return videoHandle->status;
 }
 
-int videoCapturerGetCapability(const VideoCapturerHandle const handle, VideoCapability* pCapability)
+int videoCapturerGetCapability(const VideoCapturerHandle handle, VideoCapability* pCapability)
 {
     HANDLE_NULL_CHECK(handle);
     C302_HANDLE_GET(handle);
@@ -193,7 +193,7 @@ int videoCapturerSetFormat(VideoCapturerHandle handle, const VideoFormat format,
     return 0;
 }
 
-int videoCapturerGetFormat(const VideoCapturerHandle const handle, VideoFormat* pFormat, VideoResolution* pResolution)
+int videoCapturerGetFormat(const VideoCapturerHandle handle, VideoFormat* pFormat, VideoResolution* pResolution)
 {
     HANDLE_NULL_CHECK(handle);
     C302_HANDLE_GET(handle);

--- a/source/FH8626V100/FH8626V100AudioCapturer.c
+++ b/source/FH8626V100/FH8626V100AudioCapturer.c
@@ -79,7 +79,7 @@ AudioCapturerHandle audioCapturerCreate(void)
     return (AudioCapturerHandle) audioHandle;
 }
 
-AudioCapturerStatus audioCapturerGetStatus(const AudioCapturerHandle const handle)
+AudioCapturerStatus audioCapturerGetStatus(const AudioCapturerHandle handle)
 {
     if (!handle) {
         return AUD_CAP_STATUS_NOT_READY;
@@ -89,7 +89,7 @@ AudioCapturerStatus audioCapturerGetStatus(const AudioCapturerHandle const handl
     return audioHandle->status;
 }
 
-int audioCapturerGetCapability(const AudioCapturerHandle const handle, AudioCapability* pCapability)
+int audioCapturerGetCapability(const AudioCapturerHandle handle, AudioCapability* pCapability)
 {
     HANDLE_NULL_CHECK(handle);
     HANDLE_GET(handle);
@@ -206,7 +206,7 @@ int audioCapturerSetFormat(AudioCapturerHandle handle, const AudioFormat format,
     return 0;
 }
 
-int audioCapturerGetFormat(const AudioCapturerHandle const handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
+int audioCapturerGetFormat(const AudioCapturerHandle handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
                            AudioBitDepth* pBitDepth)
 {
     HANDLE_NULL_CHECK(handle);

--- a/source/FH8626V100/FH8626V100AudioPlayer.c
+++ b/source/FH8626V100/FH8626V100AudioPlayer.c
@@ -32,12 +32,12 @@ AudioPlayerHandle audioPlayerCreate(void)
     return NULL;
 }
 
-AudioPlayerStatus audioPlayerGetStatus(const AudioPlayerHandle const handle)
+AudioPlayerStatus audioPlayerGetStatus(const AudioPlayerHandle handle)
 {
     return AUD_PLY_STATUS_NOT_READY;
 }
 
-int audioPlayerGetCapability(const AudioPlayerHandle const handle, AudioCapability* pCapability)
+int audioPlayerGetCapability(const AudioPlayerHandle handle, AudioCapability* pCapability)
 {
     return -EAGAIN;
 }
@@ -48,7 +48,7 @@ int audioPlayerSetFormat(AudioPlayerHandle handle, const AudioFormat format, con
     return -EAGAIN;
 }
 
-int audioPlayerGetFormat(const AudioPlayerHandle const handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
+int audioPlayerGetFormat(const AudioPlayerHandle handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
                          AudioBitDepth* pBitDepth)
 {
     return -EAGAIN;

--- a/source/FH8626V100/FH8626V100VideoCapturer.c
+++ b/source/FH8626V100/FH8626V100VideoCapturer.c
@@ -120,7 +120,7 @@ VideoCapturerHandle videoCapturerCreate(void)
     return (VideoCapturerHandle) videoHandle;
 }
 
-VideoCapturerStatus videoCapturerGetStatus(const VideoCapturerHandle const handle)
+VideoCapturerStatus videoCapturerGetStatus(const VideoCapturerHandle handle)
 {
     if (!handle) {
         return VID_CAP_STATUS_NOT_READY;
@@ -131,7 +131,7 @@ VideoCapturerStatus videoCapturerGetStatus(const VideoCapturerHandle const handl
     return videoHandle->status;
 }
 
-int videoCapturerGetCapability(const VideoCapturerHandle const handle, VideoCapability* pCapability)
+int videoCapturerGetCapability(const VideoCapturerHandle handle, VideoCapability* pCapability)
 {
     HANDLE_NULL_CHECK(handle);
     HANDLE_GET(handle);
@@ -186,7 +186,7 @@ int videoCapturerSetFormat(VideoCapturerHandle handle, const VideoFormat format,
     return 0;
 }
 
-int videoCapturerGetFormat(const VideoCapturerHandle const handle, VideoFormat* pFormat, VideoResolution* pResolution)
+int videoCapturerGetFormat(const VideoCapturerHandle handle, VideoFormat* pFormat, VideoResolution* pResolution)
 {
     HANDLE_NULL_CHECK(handle);
     HANDLE_GET(handle);

--- a/source/FILE/FILEAudioCapturer.c
+++ b/source/FILE/FILEAudioCapturer.c
@@ -84,7 +84,7 @@ AudioCapturerHandle audioCapturerCreate(void)
     return (AudioCapturerHandle) fileHandle;
 }
 
-AudioCapturerStatus audioCapturerGetStatus(const AudioCapturerHandle const handle)
+AudioCapturerStatus audioCapturerGetStatus(const AudioCapturerHandle handle)
 {
     if (!handle) {
         return AUD_CAP_STATUS_NOT_READY;
@@ -94,7 +94,7 @@ AudioCapturerStatus audioCapturerGetStatus(const AudioCapturerHandle const handl
     return fileHandle->status;
 }
 
-int audioCapturerGetCapability(const AudioCapturerHandle const handle, AudioCapability* pCapability)
+int audioCapturerGetCapability(const AudioCapturerHandle handle, AudioCapability* pCapability)
 {
     FILE_HANDLE_NULL_CHECK(handle);
     FILE_HANDLE_GET(handle);
@@ -170,7 +170,7 @@ int audioCapturerSetFormat(AudioCapturerHandle handle, const AudioFormat format,
     return 0;
 }
 
-int audioCapturerGetFormat(const AudioCapturerHandle const handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
+int audioCapturerGetFormat(const AudioCapturerHandle handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
                            AudioBitDepth* pBitDepth)
 {
     FILE_HANDLE_NULL_CHECK(handle);

--- a/source/FILE/FILEAudioPlayer.c
+++ b/source/FILE/FILEAudioPlayer.c
@@ -33,12 +33,12 @@ AudioPlayerHandle audioPlayerCreate(void)
     return NULL;
 }
 
-AudioPlayerStatus audioPlayerGetStatus(const AudioPlayerHandle const handle)
+AudioPlayerStatus audioPlayerGetStatus(const AudioPlayerHandle handle)
 {
     return AUD_PLY_STATUS_NOT_READY;
 }
 
-int audioPlayerGetCapability(const AudioPlayerHandle const handle, AudioCapability* pCapability)
+int audioPlayerGetCapability(const AudioPlayerHandle handle, AudioCapability* pCapability)
 {
     return -EAGAIN;
 }
@@ -49,7 +49,7 @@ int audioPlayerSetFormat(AudioPlayerHandle handle, const AudioFormat format, con
     return -EAGAIN;
 }
 
-int audioPlayerGetFormat(const AudioPlayerHandle const handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
+int audioPlayerGetFormat(const AudioPlayerHandle handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
                          AudioBitDepth* pBitDepth)
 {
     return -EAGAIN;

--- a/source/FILE/FILEVideoCapturer.c
+++ b/source/FILE/FILEVideoCapturer.c
@@ -74,7 +74,7 @@ VideoCapturerHandle videoCapturerCreate(void)
     return (VideoCapturerHandle) fileHandle;
 }
 
-VideoCapturerStatus videoCapturerGetStatus(const VideoCapturerHandle const handle)
+VideoCapturerStatus videoCapturerGetStatus(const VideoCapturerHandle handle)
 {
     if (!handle) {
         return VID_CAP_STATUS_NOT_READY;
@@ -84,7 +84,7 @@ VideoCapturerStatus videoCapturerGetStatus(const VideoCapturerHandle const handl
     return fileHandle->status;
 }
 
-int videoCapturerGetCapability(const VideoCapturerHandle const handle, VideoCapability* pCapability)
+int videoCapturerGetCapability(const VideoCapturerHandle handle, VideoCapability* pCapability)
 {
     FILE_HANDLE_NULL_CHECK(handle);
     FILE_HANDLE_GET(handle);
@@ -132,7 +132,7 @@ int videoCapturerSetFormat(VideoCapturerHandle handle, const VideoFormat format,
     return 0;
 }
 
-int videoCapturerGetFormat(const VideoCapturerHandle const handle, VideoFormat* pFormat, VideoResolution* pResolution)
+int videoCapturerGetFormat(const VideoCapturerHandle handle, VideoFormat* pFormat, VideoResolution* pResolution)
 {
     FILE_HANDLE_NULL_CHECK(handle);
     FILE_HANDLE_GET(handle);

--- a/source/SV82x/SV82xVideoCapturer.c
+++ b/source/SV82x/SV82xVideoCapturer.c
@@ -399,7 +399,7 @@ VideoCapturerHandle videoCapturerCreate(void)
     return (VideoCapturerHandle) Handle;
 }
 
-VideoCapturerStatus videoCapturerGetStatus(const VideoCapturerHandle const handle)
+VideoCapturerStatus videoCapturerGetStatus(const VideoCapturerHandle handle)
 {
     if (!handle) {
         return VID_CAP_STATUS_NOT_READY;
@@ -409,7 +409,7 @@ VideoCapturerStatus videoCapturerGetStatus(const VideoCapturerHandle const handl
     return Sv82xHandle->status;
 }
 
-int videoCapturerGetCapability(const VideoCapturerHandle const handle, VideoCapability* pCapability)
+int videoCapturerGetCapability(const VideoCapturerHandle handle, VideoCapability* pCapability)
 {
     EI_S32 s32Ret = EI_SUCCESS;
     SV82X_HANDLE_NULL_CHECK(handle);
@@ -517,7 +517,7 @@ int videoCapturerSetFormat(VideoCapturerHandle const handle, const VideoFormat f
     return 0;
 }
 
-int videoCapturerGetFormat(const VideoCapturerHandle const handle, VideoFormat* pFormat, VideoResolution* pResolution)
+int videoCapturerGetFormat(const VideoCapturerHandle handle, VideoFormat* pFormat, VideoResolution* pResolution)
 {
     SV82X_HANDLE_NULL_CHECK(handle);
     SV82X_HANDLE_GET(handle);

--- a/source/T31/T31AudioCapturer.c
+++ b/source/T31/T31AudioCapturer.c
@@ -73,7 +73,7 @@ AudioCapturerHandle audioCapturerCreate(void)
     return (AudioCapturerHandle) t31Handle;
 }
 
-AudioCapturerStatus audioCapturerGetStatus(const AudioCapturerHandle const handle)
+AudioCapturerStatus audioCapturerGetStatus(const AudioCapturerHandle handle)
 {
     if (!handle) {
         return AUD_CAP_STATUS_NOT_READY;
@@ -83,7 +83,7 @@ AudioCapturerStatus audioCapturerGetStatus(const AudioCapturerHandle const handl
     return t31Handle->status;
 }
 
-int audioCapturerGetCapability(const AudioCapturerHandle const handle, AudioCapability* pCapability)
+int audioCapturerGetCapability(const AudioCapturerHandle handle, AudioCapability* pCapability)
 {
     T31_HANDLE_NULL_CHECK(handle);
     T31_HANDLE_GET(handle);
@@ -187,7 +187,7 @@ int audioCapturerSetFormat(AudioCapturerHandle handle, const AudioFormat format,
     return 0;
 }
 
-int audioCapturerGetFormat(const AudioCapturerHandle const handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
+int audioCapturerGetFormat(const AudioCapturerHandle handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
                            AudioBitDepth* pBitDepth)
 {
     T31_HANDLE_NULL_CHECK(handle);

--- a/source/T31/T31AudioPlayer.c
+++ b/source/T31/T31AudioPlayer.c
@@ -91,7 +91,7 @@ AudioPlayerHandle audioPlayerCreate(void)
     return (AudioPlayerHandle) t31Handle;
 }
 
-int audioPlayerGetCapability(const AudioPlayerHandle const handle, AudioCapability* pCapability)
+int audioPlayerGetCapability(const AudioPlayerHandle handle, AudioCapability* pCapability)
 {
     T31_HANDLE_NULL_CHECK(handle);
     T31_HANDLE_GET(handle);
@@ -201,7 +201,7 @@ int audioPlayerSetFormat(AudioPlayerHandle handle, const AudioFormat format, con
     return 0;
 }
 
-int audioPlayerGetFormat(const AudioPlayerHandle const handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
+int audioPlayerGetFormat(const AudioPlayerHandle handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
                          AudioBitDepth* pBitDepth)
 {
     T31_HANDLE_NULL_CHECK(handle);

--- a/source/T31/T31VideoCapturer.c
+++ b/source/T31/T31VideoCapturer.c
@@ -153,7 +153,7 @@ VideoCapturerHandle videoCapturerCreate(void)
     return (VideoCapturerHandle) t31Handle;
 }
 
-VideoCapturerStatus videoCapturerGetStatus(const VideoCapturerHandle const handle)
+VideoCapturerStatus videoCapturerGetStatus(const VideoCapturerHandle handle)
 {
     if (!handle) {
         return VID_CAP_STATUS_NOT_READY;
@@ -163,7 +163,7 @@ VideoCapturerStatus videoCapturerGetStatus(const VideoCapturerHandle const handl
     return t31Handle->status;
 }
 
-int videoCapturerGetCapability(const VideoCapturerHandle const handle, VideoCapability* pCapability)
+int videoCapturerGetCapability(const VideoCapturerHandle handle, VideoCapability* pCapability)
 {
     T31_HANDLE_NULL_CHECK(handle);
     T31_HANDLE_GET(handle);
@@ -274,7 +274,7 @@ int videoCapturerSetFormat(VideoCapturerHandle handle, const VideoFormat format,
     return 0;
 }
 
-int videoCapturerGetFormat(const VideoCapturerHandle const handle, VideoFormat* pFormat, VideoResolution* pResolution)
+int videoCapturerGetFormat(const VideoCapturerHandle handle, VideoFormat* pFormat, VideoResolution* pResolution)
 {
     T31_HANDLE_NULL_CHECK(handle);
     T31_HANDLE_GET(handle);

--- a/source/V4L2/V4L2AudioCapturer.c
+++ b/source/V4L2/V4L2AudioCapturer.c
@@ -36,12 +36,12 @@ AudioCapturerHandle audioCapturerCreate(void)
     return NULL;
 }
 
-AudioCapturerStatus audioCapturerGetStatus(const AudioCapturerHandle const handle)
+AudioCapturerStatus audioCapturerGetStatus(const AudioCapturerHandle handle)
 {
     return AUD_CAP_STATUS_NOT_READY;
 }
 
-int audioCapturerGetCapability(const AudioCapturerHandle const handle, AudioCapability* pCapability)
+int audioCapturerGetCapability(const AudioCapturerHandle handle, AudioCapability* pCapability)
 {
     return -EAGAIN;
 }
@@ -52,7 +52,7 @@ int audioCapturerSetFormat(AudioCapturerHandle handle, const AudioFormat format,
     return -EAGAIN;
 }
 
-int audioCapturerGetFormat(const AudioCapturerHandle const handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
+int audioCapturerGetFormat(const AudioCapturerHandle handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
                            AudioBitDepth* pBitDepth)
 {
     return -EAGAIN;

--- a/source/V4L2/V4L2AudioPlayer.c
+++ b/source/V4L2/V4L2AudioPlayer.c
@@ -35,12 +35,12 @@ AudioPlayerHandle audioPlayerCreate(void)
     return NULL;
 }
 
-AudioPlayerStatus audioPlayerGetStatus(const AudioPlayerHandle const handle)
+AudioPlayerStatus audioPlayerGetStatus(const AudioPlayerHandle handle)
 {
     return AUD_PLY_STATUS_NOT_READY;
 }
 
-int audioPlayerGetCapability(const AudioPlayerHandle const handle, AudioCapability* pCapability)
+int audioPlayerGetCapability(const AudioPlayerHandle handle, AudioCapability* pCapability)
 {
     return -EAGAIN;
 }
@@ -51,7 +51,7 @@ int audioPlayerSetFormat(AudioPlayerHandle handle, const AudioFormat format, con
     return -EAGAIN;
 }
 
-int audioPlayerGetFormat(const AudioPlayerHandle const handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
+int audioPlayerGetFormat(const AudioPlayerHandle handle, AudioFormat* pFormat, AudioChannel* pChannel, AudioSampleRate* pSampleRate,
                          AudioBitDepth* pBitDepth)
 {
     return -EAGAIN;

--- a/source/V4L2/V4L2VideoCapturer.c
+++ b/source/V4L2/V4L2VideoCapturer.c
@@ -78,7 +78,7 @@ VideoCapturerHandle videoCapturerCreate(void)
     return (VideoCapturerHandle) v4l2Handle;
 }
 
-VideoCapturerStatus videoCapturerGetStatus(const VideoCapturerHandle const handle)
+VideoCapturerStatus videoCapturerGetStatus(const VideoCapturerHandle handle)
 {
     if (!handle) {
         return VID_CAP_STATUS_NOT_READY;
@@ -88,7 +88,7 @@ VideoCapturerStatus videoCapturerGetStatus(const VideoCapturerHandle const handl
     return v4l2Handle->status;
 }
 
-int videoCapturerGetCapability(const VideoCapturerHandle const handle, VideoCapability* pCapability)
+int videoCapturerGetCapability(const VideoCapturerHandle handle, VideoCapability* pCapability)
 {
     V4L2_HANDLE_NULL_CHECK(handle);
     V4L2_HANDLE_GET(handle);
@@ -160,7 +160,7 @@ int videoCapturerSetFormat(VideoCapturerHandle handle, const VideoFormat format,
     return 0;
 }
 
-int videoCapturerGetFormat(const VideoCapturerHandle const handle, VideoFormat* pFormat, VideoResolution* pResolution)
+int videoCapturerGetFormat(const VideoCapturerHandle handle, VideoFormat* pFormat, VideoResolution* pResolution)
 {
     V4L2_HANDLE_NULL_CHECK(handle);
     V4L2_HANDLE_GET(handle);


### PR DESCRIPTION
*Issue #, if available:*
`const xxx * const` only existing in C standard but we need to make media interface supports C++. Build current code base with C++ toolchain might get errors about the second const qualifier. 

See also #99 

*Description of changes:*
Remove the second const qualifier

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
