### PR TITLE
Fix compile error on Linux x86.

### DIFF
--- a/samples/webrtc/CMakeLists.txt
+++ b/samples/webrtc/CMakeLists.txt
@@ -76,6 +76,13 @@ target_include_directories(kvswebrtcmaster-static PRIVATE ${AWS_DEPENDENCIES_DIR
 target_link_directories(kvswebrtcmaster-static PRIVATE ${AWS_DEPENDENCIES_DIR}/webrtc/lib/ ${EMBEDDED_MEDIA_LINK_DIR})
 target_link_libraries(kvswebrtcmaster-static embedded-media-static ${WEBRTC_SDK_LIBS_STATIC} ${BOARD_LIBS_STATIC})
 
+include(CheckLibraryExists)
+CHECK_LIBRARY_EXISTS(cap cap_set_flag "" LWS_HAVE_LIBCAP)
+if (LWS_HAVE_LIBCAP)
+    target_link_libraries(kvswebrtcmaster-shared cap)
+    target_link_libraries(kvswebrtcmaster-static cap)
+endif()
+
 include(GNUInstallDirs)
 
 install(TARGETS kvswebrtcmaster-shared


### PR DESCRIPTION
When compiling libwebsockets, libcap will be checked. If libcap is already installed on the system, it will be linked to libwebsockets. Therefore, kvswebrtcmaster also needs link libcap, otherwise will meet compile error.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
